### PR TITLE
Updates to the helm chart to support load balancers within public cloud environments where required

### DIFF
--- a/charts/ibm-mq/Chart.yaml
+++ b/charts/ibm-mq/Chart.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 apiVersion: v2
 name: ibm-mq
 description: IBM MQ queue manager
-version: 2.0.0
+version: 2.0.1
 type: application
 appVersion: 9.2.5.0
 kubeVersion: ">=1.18.0-0"

--- a/charts/ibm-mq/README.md
+++ b/charts/ibm-mq/README.md
@@ -147,6 +147,8 @@ Alternatively, each paremeter can be specified by using the `--set key=value[,ke
 | `startupProbe.periodSeconds`  | How often (in seconds) to perform the probe.              | 5                                          |
 | `startupProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful.               | 1                                          |
 | `startupProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | 24              |
+| `route.loadBalancer.webconsole`     | Controls if a load balancer service is created for the MQ web console.       | `false`                                    |
+| `route.loadBalancer.mqtraffic `     | Controls if a load balancer service is created for the MQ data traffic.      | `false`                                    |
 | `route.nodePort.webconsole`     | Controls if a node port is created for the MQ web console.       | `false`                                    |
 | `route.nodePort.mqtraffic `     | Controls if a node port is created for the MQ data traffic.      | `false`                                    |
 | `route.openShiftRoute.webconsole`     | Controls if an OpenShift Route is created for the MQ web console.       | `false`                                    |

--- a/charts/ibm-mq/templates/NOTES.txt
+++ b/charts/ibm-mq/templates/NOTES.txt
@@ -11,5 +11,12 @@ Get the MQ Console URL by running these commands:
   echo https://$CONSOLE_IP:$CONSOLE_PORT/ibmmq/console
 {{ end -}}
 
+{{- if .Values.route.loadBalancer.webconsole }}
+Get the load balancer exposed MQ Console URL by running these commands:
+  export CONSOLE_PORT=9443
+  export CONSOLE_IP=$(kubectl get services {{ include "ibm-mq.fullname" . }}-loadbalancer -n {{ .Release.Namespace }} -o jsonpath="{..hostname}")$(kubectl get services {{ include "ibm-mq.fullname" . }}-loadbalancer -n {{ .Release.Namespace }} -o jsonpath="{..ip}")
+  echo https://$CONSOLE_IP:$CONSOLE_PORT/ibmmq/console
+{{ end -}}
+
 The MQ connection information for clients inside the cluster is as follows:
   {{ include "ibm-mq.fullname" . }}:1414

--- a/charts/ibm-mq/templates/service-loadbalancer.yaml
+++ b/charts/ibm-mq/templates/service-loadbalancer.yaml
@@ -1,0 +1,34 @@
+# © Copyright IBM Corporation 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if or (.Values.route.loadBalancer.mqtraffic) (.Values.route.loadBalancer.webconsole) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ibm-mq.fullname" . }}-loadbalancer
+  labels:
+    {{- include "ibm-mq.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+  {{- if .Values.route.loadBalancer.mqtraffic }}
+  - port: 1414
+    name: qmgr
+  {{- end }}
+  {{- if .Values.route.loadBalancer.webconsole }}
+  - port: 9443
+    name: console-https
+  {{- end }}
+  selector:
+{{- include "ibm-mq.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/ibm-mq/values.yaml
+++ b/charts/ibm-mq/values.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -144,6 +144,9 @@ route:
       webconsole: false
       mqtraffic: false
     openShiftRoute:
+      webconsole: false
+      mqtraffic: false
+    loadBalancer:
       webconsole: false
       mqtraffic: false
 

--- a/samples/AWSEKS/deploy/secureapp_nativeha.yaml
+++ b/samples/AWSEKS/deploy/secureapp_nativeha.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,5 +54,8 @@ metadata:
     productMetric: "FREE"
 route:
   nodePort:
+    webconsole: true
+    mqtraffic: true
+  loadBalancer:
     webconsole: true
     mqtraffic: true

--- a/samples/AWSEKS/test/getMessage.sh
+++ b/samples/AWSEKS/test/getMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ export TARGET_NAMESPACE=${1:-"default"}
 export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
-export PORT="$(kubectl get services secureapphelm-ibm-mq-qm -n $TARGET_NAMESPACE -o jsonpath='{.spec.ports[].nodePort}')"
-export IPADDRESS="$(kubectl get nodes -o jsonpath='{..addresses[1].address}' | awk '{print $1}')"
+export PORT="1414"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..hostname}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/AWSEKS/test/sendMessage.sh
+++ b/samples/AWSEKS/test/sendMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ export TARGET_NAMESPACE=${1:-"default"}
 export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
-export PORT="$(kubectl get services secureapphelm-ibm-mq-qm -n $TARGET_NAMESPACE -o jsonpath='{.spec.ports[].nodePort}')"
-export IPADDRESS="$(kubectl get nodes -o jsonpath='{..addresses[1].address}' | awk '{print $1}')"
+export PORT="1414"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..hostname}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/AzureAKS/deploy/mtlsqm.yaml_template
+++ b/samples/AzureAKS/deploy/mtlsqm.yaml_template
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,16 +43,3 @@ data:
   tls.crt: $QM_CERT
   app.crt: $APP_CERT
 type: Opaque
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: secureapphelm-ibm-mq-qm-loadbalancer
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 1414
-    name: qmgr
-  selector:
-    app.kubernetes.io/instance: secureapphelm
-    app.kubernetes.io/name: ibm-mq

--- a/samples/AzureAKS/deploy/secureapp_nativeha.yaml
+++ b/samples/AzureAKS/deploy/secureapp_nativeha.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,5 +54,8 @@ metadata:
     productMetric: "FREE"
 route:
   nodePort:
+    webconsole: true
+    mqtraffic: true
+  loadBalancer:
     webconsole: true
     mqtraffic: true

--- a/samples/AzureAKS/test/getMessage.sh
+++ b/samples/AzureAKS/test/getMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/AzureAKS/test/sendMessage.sh
+++ b/samples/AzureAKS/test/sendMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/AzureAKSFreeTier/deploy/mtlsqm.yaml_template
+++ b/samples/AzureAKSFreeTier/deploy/mtlsqm.yaml_template
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,18 +43,3 @@ data:
   tls.crt: $QM_CERT
   app.crt: $APP_CERT
 type: Opaque
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: secureapphelm-ibm-mq-qm-loadbalancer
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 1414
-    name: qmgr
-  - port: 9443
-    name: console-https
-  selector:
-    app.kubernetes.io/instance: secureapphelm
-    app.kubernetes.io/name: ibm-mq

--- a/samples/AzureAKSFreeTier/deploy/secureapp.yaml
+++ b/samples/AzureAKSFreeTier/deploy/secureapp.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,5 +50,8 @@ metadata:
     productMetric: "FREE"
 route:
   nodePort:
+    webconsole: true
+    mqtraffic: true
+  loadBalancer:
     webconsole: true
     mqtraffic: true

--- a/samples/AzureAKSFreeTier/test/getMessage.sh
+++ b/samples/AzureAKSFreeTier/test/getMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/AzureAKSFreeTier/test/sendMessage.sh
+++ b/samples/AzureAKSFreeTier/test/sendMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/GoogleKubernetesEngine/deploy/mtlsqm.yaml_template
+++ b/samples/GoogleKubernetesEngine/deploy/mtlsqm.yaml_template
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,18 +43,3 @@ data:
   tls.crt: $QM_CERT
   app.crt: $APP_CERT
 type: Opaque
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: secureapphelm-ibm-mq-qm-loadbalancer
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 1414
-    name: qmgr
-  - port: 9443
-    name: console-https
-  selector:
-    app.kubernetes.io/instance: secureapphelm
-    app.kubernetes.io/name: ibm-mq

--- a/samples/GoogleKubernetesEngine/deploy/secureapp_nativeha.yaml
+++ b/samples/GoogleKubernetesEngine/deploy/secureapp_nativeha.yaml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,5 +54,8 @@ metadata:
     productMetric: "FREE"
 route:
   nodePort:
+    webconsole: true
+    mqtraffic: true
+  loadBalancer:
     webconsole: true
     mqtraffic: true

--- a/samples/GoogleKubernetesEngine/test/getMessage.sh
+++ b/samples/GoogleKubernetesEngine/test/getMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 

--- a/samples/GoogleKubernetesEngine/test/sendMessage.sh
+++ b/samples/GoogleKubernetesEngine/test/sendMessage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# © Copyright IBM Corporation 2021
+# © Copyright IBM Corporation 2021, 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ export MQCCDTURL="${DIR}/ccdt_generated.json"
 export MQSSLKEYR="${DIR}/../../genericresources/createcerts/application"
 
 export PORT="1414"
-export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-qm-loadbalancer -o jsonpath='{..ip}')"
+export IPADDRESS="$(kubectl get service secureapphelm-ibm-mq-loadbalancer -o jsonpath='{..ip}')"
 
 ( echo "cat <<EOF" ; cat ccdt_template.json ; echo EOF ) | sh > ccdt_generated.json
 


### PR DESCRIPTION
Adding support to the helm chart for exposing the MQ Data and Web Console ports via a load balancer.
I've deliberately combined this into a single service, instead of following the previous pattern of two separate Kubernetes services.
This is due to the potential for cloud environments to charge differently, and ideally I wanted to minimize. Clearly this can be customized based on individual requirements. 