### PR TITLE
Add namespace metadata to the templates

### DIFF
--- a/charts/ibm-mq/templates/metrics-service.yaml
+++ b/charts/ibm-mq/templates/metrics-service.yaml
@@ -22,6 +22,7 @@ metadata:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9157'
   name: '{{ include "ibm-mq.fullname" . }}-metrics'
+  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/route-qm.yaml
+++ b/charts/ibm-mq/templates/route-qm.yaml
@@ -17,6 +17,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: "{{ include "ibm-mq.fullname" . }}-qm"
+  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/route-web.yaml
+++ b/charts/ibm-mq/templates/route-web.yaml
@@ -17,6 +17,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: "{{ include "ibm-mq.fullname" . }}-web"
+  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/service-loadbalancer.yaml
+++ b/charts/ibm-mq/templates/service-loadbalancer.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.fullname" . }}-loadbalancer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/service-nativeha.yaml
+++ b/charts/ibm-mq/templates/service-nativeha.yaml
@@ -17,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.pod0.service" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:
@@ -32,6 +33,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.pod1.service" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:
@@ -47,6 +49,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.pod2.service" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/service-qm.yaml
+++ b/charts/ibm-mq/templates/service-qm.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.fullname" . }}-qm
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/service-web.yaml
+++ b/charts/ibm-mq/templates/service-web.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/service.yaml
+++ b/charts/ibm-mq/templates/service.yaml
@@ -15,6 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ibm-mq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:

--- a/charts/ibm-mq/templates/serviceaccount.yaml
+++ b/charts/ibm-mq/templates/serviceaccount.yaml
@@ -15,6 +15,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ibm-mq.fullname" ( . ) }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 imagePullSecrets:

--- a/charts/ibm-mq/templates/stateful-set.yaml
+++ b/charts/ibm-mq/templates/stateful-set.yaml
@@ -19,6 +19,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $statefulSetName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
 spec:
@@ -38,6 +39,7 @@ spec:
   {{- end }}
   template:
     metadata:
+      namespace: {{ .Release.Namespace }}
       annotations:
       {{- with .Values.metadata.annotations }}
         {{- toYaml . | nindent 8 }}
@@ -449,6 +451,7 @@ spec:
   {{- if .Values.persistence.dataPVC.enable }}
   - metadata:
       name: {{ $dataVolumeClaimName }}
+      namespace: {{ .Release.Namespace }}
       labels:
 {{- include "ibm-mq.labels" . | nindent 8 }}
     spec:
@@ -465,6 +468,7 @@ spec:
   {{- if .Values.persistence.logPVC.enable }}
   - metadata:
       name: {{ $logVolumeClaimName }}
+      namespace: {{ .Release.Namespace }}
       labels:
 {{- include "ibm-mq.labels" . | nindent 8 }}
     spec:
@@ -481,6 +485,7 @@ spec:
   {{- if .Values.persistence.qmPVC.enable }}
   - metadata:
       name: {{ $qmVolumeClaimName }}
+      namespace: {{ .Release.Namespace }}
       labels:
 {{- include "ibm-mq.labels" . | nindent 8 }}
     spec:

--- a/samples/AWSEKS/deploy/install.sh
+++ b/samples/AWSEKS/deploy/install.sh
@@ -31,4 +31,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml $MQ_ADMIN_PASSWORD_NAME $MQ_ADMIN_PASSWORD_VALUE $MQ_APP_PASSWORD_NAME $MQ_APP_PASSWORD_VALUE
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml $MQ_ADMIN_PASSWORD_NAME $MQ_ADMIN_PASSWORD_VALUE $MQ_APP_PASSWORD_NAME $MQ_APP_PASSWORD_VALUE

--- a/samples/AzureAKS/deploy/install.sh
+++ b/samples/AzureAKS/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/AzureAKSFreeTier/deploy/install.sh
+++ b/samples/AzureAKSFreeTier/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp.yaml

--- a/samples/GoogleKubernetesEngine/deploy/install.sh
+++ b/samples/GoogleKubernetesEngine/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/IBMKubernetesService/deploy/install.sh
+++ b/samples/IBMKubernetesService/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/Minikube/deploy/install.sh
+++ b/samples/Minikube/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/OpenShiftIBMPower/deploy/install.sh
+++ b/samples/OpenShiftIBMPower/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 oc project $TARGET_NAMESPACE
 oc apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f ibmpower.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f ibmpower.yaml

--- a/samples/OpenShiftNativeHA/deploy/install.sh
+++ b/samples/OpenShiftNativeHA/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 oc project $TARGET_NAMESPACE
 oc apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/OpenShiftNativeHAMQAdvancedContainer/deploy/install.sh
+++ b/samples/OpenShiftNativeHAMQAdvancedContainer/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 oc project $TARGET_NAMESPACE
 oc apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml

--- a/samples/PerformanceSniffTest/deploy/install.sh
+++ b/samples/PerformanceSniffTest/deploy/install.sh
@@ -22,4 +22,4 @@ export QM_CERT=$(cat ../../genericresources/createcerts/server.crt | base64 | tr
 
 oc apply -f resource.yaml
 
-helm install perfhelm ../../../charts/ibm-mq -f perfhelm_nativeha.yaml
+helm install -n $TARGET_NAMESPACE perfhelm ../../../charts/ibm-mq -f perfhelm_nativeha.yaml

--- a/samples/VMwareTanzu/deploy/install.sh
+++ b/samples/VMwareTanzu/deploy/install.sh
@@ -23,4 +23,4 @@ export APP_CERT=$(cat ../../genericresources/createcerts/application.crt | base6
 kubectl config set-context --current --namespace=$TARGET_NAMESPACE
 kubectl apply -f mtlsqm.yaml
 
-helm install secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml
+helm install -n $TARGET_NAMESPACE secureapphelm ../../../charts/ibm-mq -f secureapp_nativeha.yaml


### PR DESCRIPTION
Without this field running `helm template --namespace <namespace>` will not fill it. See https://github.com/helm/helm/issues/10737

It should not affect any examples using helm. I'm not sure about direct kubectl calls. Should I update examples to use `--namespace`?

Also, what kind of chart version bump should I add if this PR would get to be accepted? 