### PR TITLE
Tmp add loadBalancerIP to service-loadbalancer template

### DIFF
--- a/charts/ibm-mq/templates/service-loadbalancer.yaml
+++ b/charts/ibm-mq/templates/service-loadbalancer.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 {{- if or (.Values.route.loadBalancer.mqtraffic) (.Values.route.loadBalancer.webconsole) }}
 apiVersion: v1
 kind: Service
@@ -26,6 +25,7 @@ metadata:
   {{- end }}    
 spec:
   type: LoadBalancer
+  loadBalancerIP: {{ .Values.route.loadBalancer.loadBalancerIP }}
   ports:
   {{- if .Values.route.loadBalancer.mqtraffic }}
   - port: 1414


### PR DESCRIPTION
https://apexclearing.atlassian.net/browse/PLT-7717

Temporarily adding `loadBalancerIP` field to service-loadbalancer template. This field is deprecated by k8s 1.24 but gke has not released anything to replace it. We are using it until we either do istio or find a metadata:annotation to replace it. 