### PR TITLE
Support custom IP addresses in load balancer service

### DIFF
--- a/charts/ibm-mq/README.md
+++ b/charts/ibm-mq/README.md
@@ -168,6 +168,7 @@ Alternatively, each parameter can be specified by using the `--set key=value[,ke
 | `route.ingress.webconsole.tls.enable `     | If TLS is enabled for the web console ingress.      | `false`                                    |
 | `route.ingress.webconsole.tls.secret `     | The kubernetes secret containing the certificates to be used.      | `false`                                   |
 | `route.loadBalancer.annotations`          | Additional annotations to be added to the load balancer service.                 |`{}`                                      |
+| `route.loadBalancer.loadBalancerIP`          | Single IP address to be explcitly defined as the load balancer's external address. This field, while in the process of being deprecated, still does not have replacements available in all cloud providers, i.e. its an alternative to when the IP spec cannot be set through annotations  |`nil`                  |
 | `route.loadBalancer.loadBalancerSourceRanges`          | This is an array of CIDRs that can be added to a loadbalancer to restrict traffic      |`[]`                  |
 | `route.loadBalancer.mqtraffic `     | Controls if a load balancer service is created for the MQ data traffic.      | `false`                                    |
 | `route.loadBalancer.webconsole`     | Controls if a load balancer service is created for the MQ web console.       | `false`                                    |

--- a/charts/ibm-mq/templates/service-loadbalancer.yaml
+++ b/charts/ibm-mq/templates/service-loadbalancer.yaml
@@ -23,9 +23,12 @@ metadata:
   {{- with .Values.route.loadBalancer.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }}    
+  {{- end }}
 spec:
   type: LoadBalancer
+  {{- if .Values.route.loadBalancer.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.route.loadBalancer.loadBalancerIP }}
+  {{- end }}
   ports:
   {{- if .Values.route.loadBalancer.mqtraffic }}
   - port: 1414


### PR DESCRIPTION
On one hand the `spec.loadBalancerIP` field is [being deprecated](https://github.com/kubernetes/kubernetes/pull/107235), but on the other its been over two years since it was marked as deprecated without [any concrete plans to actually drop it](https://github.com/kubernetes/kubernetes/pull/107235#issuecomment-1316952460). Its seems to be more of a warning.

In the meanwhile, some cloud providers give access to a similar functionality through annotations (e.g. [Azure](https://learn.microsoft.com/en-us/azure/aks/internal-lb?tabs=set-service-annotations#specify-an-ip-address)) while others still rely on the deprecated field (e.g. [GCP](https://stackoverflow.com/questions/73750700/what-is-the-replacement-for-the-deprecated-loadbalancerip-attribute-in-services)).

In order to allow custom IP addresses for LoadBalancers, this MR adds an optional config to enable said behaviour (without needing to do any `kubectl patch`s after installing the chart). If undefined k8s will just pick a random available address from the LoadBalancer's subnet.