### PR TITLE
Fix mqwebuser.xml example by adding root server element

### DIFF
--- a/charts/ibm-mq/README.md
+++ b/charts/ibm-mq/README.md
@@ -389,7 +389,10 @@ metadata:
   name: mywebconfig
 data:
   mqwebuser.xml: |-
-    <variable name="myCustomVariable" value="*"/>
+    <?xml version="1.0" encoding="UTF-8"?>
+    <server>
+      <variable name="myCustomVariable" value="*"/>
+    </server>
 ```
 
 ## Supplying licensing annotations


### PR DESCRIPTION
The example `mqwebuser.xml` is currently incorrect, and causes an XML parsing FDC in Liberty.  The example needs a `server` root element.