### PR TITLE
Fix the readiness probe using a sidecar container

### DIFF
--- a/charts/ibm-mq/templates/role-binding.yaml
+++ b/charts/ibm-mq/templates/role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-labeler-binding
+  namespace: ready-check
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: pod-labeler
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ibm-mq.fullname" ( . ) }}
+  namespace: ready-check

--- a/charts/ibm-mq/templates/role.yaml
+++ b/charts/ibm-mq/templates/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-labeler
+  namespace: ready-check
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list","patch"]

--- a/charts/ibm-mq/templates/service.yaml
+++ b/charts/ibm-mq/templates/service.yaml
@@ -26,3 +26,4 @@ spec:
     name: qmgr
   selector:
 {{- include "ibm-mq.selectorLabels" . | nindent 4 }}
+    role: master

--- a/charts/ibm-mq/templates/stateful-set.yaml
+++ b/charts/ibm-mq/templates/stateful-set.yaml
@@ -272,8 +272,46 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.credentials.secret }}
       {{- end }}
+      volumes:
+      - name: state
+        emptyDir: {}
       terminationGracePeriodSeconds: {{.Values.queueManager.terminationGracePeriodSeconds}}
       containers:
+        - name: state-checker
+          command:
+            - sh
+            - '-c'
+            - >
+              sleep 20;
+              while true; do
+                sleep $(($RANDOM % 5 + 5));
+                KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+                echo "Checking state of the queue manager"
+                STATE=$(cat /etc/mqm/state/test)
+                if [ $STATE -eq 0 ]; then
+                echo "Queue manager is active"
+                echo "patching the label:"
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                    --request PATCH \
+                    --header "Content-Type: application/json-patch+json" \
+                    --data '[ { "op": "replace", "path": "/metadata/labels/role", "value": "master" } ]' \
+                    https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$NAMESPACE/pods/$HOSTNAME
+                else
+                echo "Queue manager is not active"
+                echo "patching the label:"
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                    --header "Content-Type: application/json-patch+json" \
+                    --request PATCH \
+                    --data '[ { "op": "replace", "path": "/metadata/labels/role", "value": "standby" } ]' \
+                    https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$NAMESPACE/pods/$HOSTNAME
+                fi
+              done
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /etc/mqm/state
+              name: state
         - name: qmgr
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -371,6 +409,8 @@ spec:
           {{- else if .Values.web.manualConfig.secret.name }}
           volumeMounts:
           {{- end}}
+          - name: state
+            mountPath: /etc/mqm/state
           {{- if .Values.queueManager.nativeha.tls }}
           {{- if .Values.queueManager.nativeha.tls.secretName }}
           - name: ha-tls
@@ -493,7 +533,11 @@ spec:
           readinessProbe:
             exec:
               command:
-              - chkmqready
+              - sh
+              - '-c'
+              - >
+                chkmqready;
+                echo $? > /etc/mqm/state/test
             {{- if or .Values.queueManager.nativeha.enable .Values.queueManager.multiinstance.enable }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 0 }}
             {{- else }}


### PR DESCRIPTION
Hi,
This MR aims to fix the readiness check regarding the helm chart.

The original solution caused the StatefulSet to be not upgradable by standard k8s methods and further problems using GitOps tools(ArgoCD and its health checks).
Additionally, readiness alerts and further things cause problems with the current solution.

(https://community.ibm.com/community/user/integration/discussion/ibm-mq-nativeha-on-kubernetes-with-ibm-messagingmq-helm-chart)

Original Solution:
Only one pod has a readiness check that runs successfully -> service will only serve the leader instance

This Solution:
Patch the label in a sidecar container -> service will only serve the leader instance (via selector)

Thanks for reading this far. I will happily welcome any feedback.
Best Regards,
Lorenz