### PR TITLE
Add disableDefaultPullSecret config for imagePullSecret

### DIFF
--- a/charts/ibm-mq/templates/serviceaccount.yaml
+++ b/charts/ibm-mq/templates/serviceaccount.yaml
@@ -17,8 +17,10 @@ metadata:
   name: {{ include "ibm-mq.fullname" ( . ) }}
   labels:
     {{- include "ibm-mq.labels" . | nindent 4 }}
+{{- if not .Values.image.disableDefaultPullSecret }}
 imagePullSecrets:
   - name: ibm-entitlement-key
 {{- if .Values.image.pullSecret }}
   - name: {{ .Values.image.pullSecret }}
+{{- end }}
 {{- end }}

--- a/charts/ibm-mq/values.yaml
+++ b/charts/ibm-mq/values.yaml
@@ -20,6 +20,8 @@ image:
   repository: icr.io/ibm-messaging/mq
   # tag is the tag to use for the container repository
   tag: 9.4.0.0-r3
+  # disableDefaultPullSecret to use when pulling the image from a private registry without a pull secret
+  disableDefaultPullSecret: false
   # pullSecret is the secret to use when pulling the image from a private registry
   pullSecret:
   # pullPolicy is either IfNotPresent or Always (https://kubernetes.io/docs/concepts/containers/images/)


### PR DESCRIPTION
Hellow @callumpjackson, @daniel-geiger-ibmde

This fixes https://github.com/ibm-messaging/mq-helm/issues/111

Adds an opt out config for the imagePullSecret on the ServiceAccount .

Best regards and have a nice Day,
Lorenz