### PR TITLE
Fix webconsole Ingress

### DIFF
--- a/charts/ibm-mq/templates/service-ingress.yaml
+++ b/charts/ibm-mq/templates/service-ingress.yaml
@@ -37,9 +37,9 @@ spec:
     - host: {{ .Values.route.ingress.webconsole.hostname }}
       http:
   {{- else }}
-      - http:
+    - http:
   {{- end }}
-          paths:
+        paths:
   {{- if .Values.route.ingress.webconsole.path }}
           - path: {{ .Values.route.ingress.webconsole.path }}
   {{- else }}
@@ -53,10 +53,10 @@ spec:
                   name: console-https
   {{- if .Values.route.ingress.webconsole.tls.enable }}
   tls:
-    {{- if .Values.route.ingress.webconsole.hostname}}
+    {{- if .Values.route.ingress.webconsole.hostname }}
     - hosts:
-      - {{ .Values.route.ingress.webconsole.hostname }}
-      {{- if .Values.route.ingress.webconsole.tls.secret}}
+        - {{ .Values.route.ingress.webconsole.hostname }}
+      {{- if .Values.route.ingress.webconsole.tls.secret }}
       secretName: {{ .Values.route.ingress.webconsole.tls.secret }}
       {{- end }}
     {{- else }}

--- a/charts/ibm-mq/templates/service-ingress.yaml
+++ b/charts/ibm-mq/templates/service-ingress.yaml
@@ -48,7 +48,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "ibm-mq.fullname" . }}-web
+                name: {{ include "ibm-mq.fullname" . }}
                 port:
                   number: 9443
   {{- if .Values.route.ingress.webconsole.tls.enable }}

--- a/charts/ibm-mq/templates/service-ingress.yaml
+++ b/charts/ibm-mq/templates/service-ingress.yaml
@@ -30,7 +30,7 @@ spec:
     service:
       name: {{ include "ibm-mq.fullname" . }}
       port:
-        number: 9443
+        name: console-https
   ingressClassName: nginx
   rules:
   {{- if .Values.route.ingress.webconsole.hostname }}
@@ -50,7 +50,7 @@ spec:
               service:
                 name: {{ include "ibm-mq.fullname" . }}
                 port:
-                  number: 9443
+                  name: console-https
   {{- if .Values.route.ingress.webconsole.tls.enable }}
   tls:
     {{- if .Values.route.ingress.webconsole.hostname}}


### PR DESCRIPTION
The Ingress for webconsole has no reason to target the NodePort service of the webconsole, which is not necessarily enabled.
Instead, just target the ClusterIP service, which is always deployed.

Also use port name instead of port number.
And fix indentation consistency.