### PR TITLE
Fix case of readOnlyRootFilesystem while not persisting with PVC nor using multiinstance

### DIFF
--- a/charts/ibm-mq/templates/stateful-set.yaml
+++ b/charts/ibm-mq/templates/stateful-set.yaml
@@ -322,6 +322,18 @@ spec:
         emptyDir: {}
       - name: tmp-volume
         emptyDir: {}
+      {{- if not (or .Values.persistence.qmPVC.enable .Values.queueManager.multiinstance.enable) }}
+      - name: mqm-volume
+        emptyDir: {}
+      {{- end }}
+      {{- if not (or .Values.persistence.dataPVC.enable .Values.queueManager.multiinstance.enable) }}
+      - name: mqm-data-volume
+        emptyDir: {}
+      {{- end }}
+      {{- if not (or .Values.persistence.logPVC.enable .Values.queueManager.multiinstance.enable) }}
+      - name: mqm-log-volume
+        emptyDir: {}
+      {{- end }}
       {{- end }}
       {{- if .Values.credentials.enable }}
       - name: mq-credentials
@@ -488,14 +500,23 @@ spec:
           {{- if or .Values.persistence.qmPVC.enable .Values.queueManager.multiinstance.enable }}
           - mountPath: "/mnt/mqm"
             name: {{ $qmVolumeClaimName }}
+          {{- else if .Values.security.readOnlyRootFilesystem }}
+          - mountPath: "/mnt/mqm"
+            name: mqm-volume
           {{- end }}
           {{- if or .Values.persistence.dataPVC.enable .Values.queueManager.multiinstance.enable }}
           - mountPath: "/mnt/mqm-data"
             name: {{ $dataVolumeClaimName }}
+          {{- else if .Values.security.readOnlyRootFilesystem }}
+          - mountPath: "/mnt/mqm-data"
+            name: mqm-data-volume
           {{- end }}
           {{- if or .Values.persistence.logPVC.enable .Values.queueManager.multiinstance.enable }}
           - mountPath: "/mnt/mqm-log"
             name: {{ $logVolumeClaimName }}
+          {{- else if .Values.security.readOnlyRootFilesystem }}
+          - mountPath: "/mnt/mqm-log"
+            name: mqm-log-volume
           {{- end }}
           {{- if $crrDeclared }}
             {{- if .Values.queueManager.nativeha.enable }}


### PR DESCRIPTION
Currently failing because of read-only FS with this configuration as the paths `/mnt/mqm*` are on the container read-only FS:

```yaml
security:
  readOnlyRootFilesystem: true
persistence:
  qmPVC:
    enable: false
  dataPVC:
    enable: false
  logPVC:
    enable: false
queueManager:
  multiinstance:
    enable: false
```

This PR handle this situation by using `emptyDir` volumes like for `/run` & `/tmp`.

I know this situation is not a production mode, but for development where persistence is not useful but in context where the read-only FS is mandatory, it can be configured this way.